### PR TITLE
Changes required to work with Virtuoso LDP

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -58,6 +58,9 @@ RUN adduser --disabled-password --gecos "P3 Platform" --uid 3000 p3
 ENV HOME /home/p3
 WORKDIR /home/p3
 
+ADD ldp_config_vos.js ldp_config_vos.js
+ADD ldp_config_marmotta.js ldp_config_marmotta.js
+
 #ADD ELK/logstash-forwarder.conf /etc/
 
 

--- a/core/README.md
+++ b/core/README.md
@@ -14,9 +14,19 @@ If instead you want to build it yourself, clone the github repository and run:
 
 ## Running
 
+### Using Marmotta LDP
+
 To access the Fusepool P3 entry page at the default port 80 start the docker like that
 
     docker run --privileged -d --name=p3-platform -p 80:80 -p 8181:8181 -p 8151:8151 -p 8200:8200 -p 8201:8201 -p 8202:8202 -p 8203:8203 -p 8204:8204 -p 8205:8205 -p 8300:8300 -p 8301:8301 -p 8302:8302 -p 8303:8303 -p 8304:8304 -p 8305:8305 -p 8306:8306 -p 8307:8307 -p 8308:8308 -p 8310:8310 -p 8386:8386 -p 8387:8387 -p 8388:8388 fusepoolp3/platform-reference-implementat
+    
+### Using VOS LDP
+
+The P3 platform uses Marmotta as the default LDP server. VOS (Virtuoso Open Source) provides an alternative LDP service. To use VOS as the LDP backend, start the platform using:
+
+    docker run --privileged -d --name=p3-platform --link vos:vos --env LDPURI=http://vos:8890/ --env LDP_HOST=vos -p 80:80 --add-host {container-host-name}:{container-host-ip-address} -p 8181:8181 -p 8151:8151 -p 8200:8200 -p 8201:8201 -p 8202:8202 -p 8203:8203 -p 8204:8204 -p 8205:8205 -p 8300:8300 -p 8301:8301 -p 8302:8302 -p 8303:8303 -p 8304:8304 -p 8305:8305 -p 8306:8306 -p 8307:8307 -p 8308:8308 -p 8310:8310 -p 8386:8386 -p 8387:8387 -p 8388:8388  fusepoolp3/platform-reference-implementat
+
+In this example, `vos` identifies a container hosting a VOS database instance, running on port 8890 (see [virtuoso-docker](https://github.com/fusepoolP3/virtuoso-docker) for details of  running VOS in Docker). When omitted, the environment variables `LDP_HOST` and `LDP_URI` default to `marmotta` and `http://localhost:8080/`. [ldp_config_vos.js](https://github.com/fusepoolP3/p3-platform-reference-implementation/blob/master/core/ldp_config_vos.js) and [ldp_config_marmotta.js](https://github.com/fusepoolP3/p3-platform-reference-implementation/blob/master/core/ldp_config_marmotta.js) specify the platform LDP root container and sparql endpoint paths. In the case of VOS, the LDP root container must be preconfigured in the database instance.
 
 To stop the container:
 
@@ -46,7 +56,7 @@ locally using /localhost/ is just fine.
 The different components of Fusepool P3 
 can be accessed over the ports exposed by the container. Curently, these are:
 
-* 8181 - Fusepool's Marmotta LDP over [p3-proxy](https://github.com/fusepoolP3/p3-proxy)
+* 8181 - Fusepool's LDP over [p3-proxy](https://github.com/fusepoolP3/p3-proxy)
 * 8151 - [p3-transformer-web-client](https://github.com/fusepoolP3/p3-transformer-web-client)
 * 8200 - [p3-dashboard](https://github.com/fusepoolP3/p3-dashboard)
 * 8201 - [p3-pipeline-gui-js](https://github.com/fusepoolP3/p3-pipeline-gui-js)

--- a/core/index.html
+++ b/core/index.html
@@ -7,6 +7,7 @@
         <script src="/js/autoconfig/p3-check.js"></script>
         <script src="/js/rdf2h/dist/rdf2h.js"></script>
         <script src="/js/ld2h/js/ld2h.js"></script>
+	<script src="/js/ldp_config.js"></script>
         <script>
             $(function () {
 
@@ -25,8 +26,9 @@
                 };
 
                 var host = window.location.hostname;
-                var platformURI = "http://" + host + ":8181/ldp/platform";
-                P3Check.initP3Platform(platformURI, "http://" + host + ":8181/sparql/select").then(
+                var platformURI = "http://" + host + ":8181" + LDPServerPaths.platformLDPRoot + "platform";
+                var platformLDPRootURI = "http://" + host + ":8181" + LDPServerPaths.platformLDPRoot;
+                P3Check.initP3Platform(platformURI, "http://" + host + ":8181" + LDPServerPaths.sparqlEndpoint).then(
                         function (platform) {
                             var registartionJobs = [];
                             registartionJobs.push(platform.registerFactory(
@@ -55,10 +57,13 @@
                                                                 });
                                                         }, window.location.toString());
                                                         $(".dashboard-link").attr("href", "http://" + host + ":8200/?platformURI=" + platformURI);
+                                                        $(".resource-gui-link").attr("href", "http://" + host + ":8205/?defaultContainer=" + platformLDPRootURI);
                                                         $(".host").each(
                                                         function () {
                                                         $(this).text(host)
                                                         });
+                                                        $(".platformURI").each(function () { $(this).text(platformURI) });
+                                                        $(".platformLDPRootURI").each(function () { $(this).text(platformLDPRootURI) });
                                                         $("a").each(
                                                         function () {
                                                         var origHref = $(this).attr("href");
@@ -212,12 +217,12 @@ Supported Output Formats:<br/>
             <h2>P3 Resource GUI</h2>
 
             <p>This is a graphical user interface to deal with Linked-Data-Platform-Collections.</p>
-            <a href="http://{host}:8205/?defaultContainer=http://{host}:8181/ldp"><span class="host"></span>:8205/?defaultContainer=<span class="host"></span>:8181/ldp</a>
+            <a class="resource-gui-link"><span class="host"></span>:8205/?defaultContainer=<span class="platformLDPRootURI"></span></a>
 
             <h2>P3 Dashboard</h2>
 
             <p>P3 administrator dashboard is the main user interface for uploading files easily to the platform using transformers. 
-                <a class="dashboard-link"><span class="host"></span>:8200/?platformURI=http://<span class="host"></span>:8181/ldp/platform</a></p>
+                <a class="dashboard-link"><span class="host"></span>:8200/?platformURI=<span class="platformURI"></span></a></p>
 
             <h2>Transformer Web Client</h2>
             

--- a/core/ldp_config_marmotta.js
+++ b/core/ldp_config_marmotta.js
@@ -1,0 +1,6 @@
+// LDP server paths for Marmotta
+var LDPServerPaths = {
+  platformLDPRoot: "/ldp/",
+  sparqlEndpoint: "/sparql/select"
+};
+

--- a/core/ldp_config_vos.js
+++ b/core/ldp_config_vos.js
@@ -1,0 +1,6 @@
+// LDP server paths for Virtuoso / VOS
+var LDPServerPaths = {
+  platformLDPRoot: "/DAV/home/fusepool/ldp/",
+  sparqlEndpoint: "/sparql"
+};
+

--- a/core/startup.sh
+++ b/core/startup.sh
@@ -17,10 +17,24 @@ httpry -f source-ip,request-uri -d -i eth0 'tcp port 8080 or 8181 or 8151 or 820
 
 #iptables -A INPUT  -j LOG  --log-level debug --log-prefix '[p3-platform] '
 
-# LDP
-su p3 -s /usr/bin/java -- -jar /usr/local/lib/p3-ldp-marmotta.jar > /var/log/ldp-marmotta.log 2>&1  &       	# Port 8080
+case ${LDP_HOST:=marmotta} in
+  marmotta)
+    echo "Using Marmotta LDP server"
+    ;;
+  vos)  
+    echo "Using VOS LDP server"
+    ;;
+  *) echo "Unknown LDP_HOST"; exit 1;;
+esac
+
+cp ./ldp_config_${LDP_HOST}.js /var/www/html/js/ldp_config.js
+
+# LDP:
+# Use Marmotta as the default LDP.
+# To use Virtuoso as the LDP server, start the container using: 
+# docker run --link vos:vos --env LDPURI=http://vos:8890/ --env LDP_HOST=vos ...
 if [ -z "$LDPURI" ]; then
-    echo ldp uri is set
+    su p3 -s /usr/bin/java -- -jar /usr/local/lib/p3-ldp-marmotta.jar > /var/log/ldp-marmotta.log 2>&1  &       	# Port 8080
     export LDPURI=http://localhost:8080/
 fi
 


### PR DESCRIPTION
Changes to provide a common codebase for the platform to use either Marmotta or VOS LDP. The LDP server to be used by the platform is configured when the platform container is launched using environment variables.

docker-compose.yml not yet updated
